### PR TITLE
Fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,55 +8,56 @@ Listen to music from youtube inside terminal with sleek tui
 ---
 
 # Installation
-1) Download latest binary from [release page](https://github.com/sudipghimire533/ytui-music/releases/latest).
-If binary is not available for your platform head on to [build from source](#building-from-source)
+1) Download the latest binary from [release page](https://github.com/sudipghimire533/ytui-music/releases/latest).
+If the binary is not available for your platform head on to [build from source](#building-from-source)
 
 2) Give it executable permission and from downloaded directory, in shell:
 ```
-ytui_music run
+./ytui_music run
 ```
 3) You may need to jump to [Usage Guide](#usage)
 
 ---
 
 ## Dependencies
-Ytui-music depends on mpv and youtube-dl. You may refer to the offical [website of mpv](https://mpv.io) and [website of youtube-dl](https://yt-dl.org).
+ytui-music depends on `mpv` and `youtube-dl`. You may refer to the offical [website of mpv](https://mpv.io) and [website of youtube-dl](https://yt-dl.org).
 
-If you have `choco` for windows or `brew` in mac or one of popular package manager in linux you may do:
+If you have `choco` for windows or `brew` on mac or one of the popular package managers in linux you can do:
 
 ### - Windows (In powershell or cmd)
 ```
 choco install mpv youtube-dl
 ```
 
-### - Mac
+### - MacOS
 ```
 brew install mpv youtube-dl
 ```
 
-### - Debain/ Ubuntu Deriatives
+### - Debian/ Ubuntu Derivatives
 ```
 sudo apt update && sudo apt install youtube-dl libmpv1
 ```
-**For other distribution install youtube-dl and mpv package the way you please**
+
+**For other distributions install `youtube-dl` and `mpv` packages any way you please**
 
 ---
 
 # Before running ytui-music
-Before you start with ytui-music make sure that Following directory exist and have write permission to ytui-music in order to save configuration file
+Before you start ytui-music make sure the following directory exists and that ytui-music has the write permission in order to save the configuration file.
 ## Windows
-`C:\Users\<username>\AppData\Roaming` or anv var `{FOLDERID_RoamingAppData}`
+`C:\Users\<username>\AppData\Roaming` or env var `{FOLDERID_RoamingAppData}`
 
-## Mac
-`/Users/<username>/Library/Application Support` or  `$HOME/Library/Application Support`
+## MacOS
+`$HOME/Library/Application Support`
 
 ## Linux
-`$HOME/.config/` or `/home/<username>/.config` or env var `$XDG_CONFIG_HOME`
+`$HOME/.config/` or the env var `$XDG_CONFIG_HOME`
 
 ---
 
 # Building from Source
-Ytui-music is written entirely in Rust and thus making is dead simple to build from source. All you have to do is download source, install rust and build with cargo.
+`ytui-music` is written entirely in Rust and thus making it dead simple to build from source. All you have to do is download the source, install `rust` and build with `cargo`.
 
 1) Installing rust. Head to [Rust installation](https://www.rust-lang.org/tools/install). It is basically doing
 ```
@@ -80,7 +81,7 @@ cargo build --all --release
 
 # Usage
 
-ytui-music is single binary so it shouldn't be of any hassale to run. Just make sure you have [installation of dependencies](#dependencies).
+ytui-music is a single binary so it shouldn't be a hassle to run it. Just make sure you have [installation of dependencies](#dependencies).
 
 ### - Running ytui-music
 ```
@@ -96,53 +97,53 @@ ytui_music info shortcuts
 ```
 ### - Showing version information
 ```
-ytui_music infor version
+ytui_music info version
 ```
 
 ## Searching
 1) Press `/` to go to search box
 2) Type
-    - `music:Bartika Eam Rai` to search only for music result for query "Bartika Eam Rai"
-    - `playlist:Soft pop hits` to search only for playlist for query "Soft pop hits"
-    - `artist:Bibash Jk` to search only for artist for query "Bibash Jk"
-    - `Coding music` to search all of playlist, music and artist at once for query "Coding music"
-3) Press `Enter` key
+    - `music:Bartika Eam Rai` to search only music results with the query "Bartika Eam Rai"
+    - `playlist:Soft pop hits` to search only playlist results with the query "Soft pop hits"
+    - `artist:Bibash Jk` to search only artists with the query "Bibash Jk"
+    - `Coding music` to search playlists, music and artists at once with the query "Coding music"
+3) Press the `Enter` key
 
 ## Navigating
 - Use `Left arrow` or `Backspace` for backward and `Right arrow` or `Tab` key for forward to **move between Sidebar, Musicbar, Playlistbar and Artistbar**
-- Use `Up arrow` or `Down arrow` to move up or down in the list which will **hilight the list item**
+- Use `Up arrow` or `Down arrow` to move up or down in the list which will **highlight the list item**
 - Press `Enter` key to **select an item**
 
 ## Playback control
 - Press `Space` key **to pause/unpause the playback**
-- Press `s` key to **toggle suffle/unsuffle**
-- Press `r` key to **repeat single or all item in playlist**
+- Press `s` key to **toggle shuffle/unshuffle**
+- Press `r` key to **repeat one or all items in playlist**
 - Press `>` for forward and `<` for backward **playback seek**
 - Press `CTRL+n` for next and `CTRL+p` to **change track**
 
 ## Downloading
-1) Hilight the item you want to download. Currently downloading of music and playlist is supported.
+1) Highlight the item you want to download. Currently supported is downloading of music and playlists.
 2) Press `CTRL+d` to **download the selection**
 
 ## Quitting
 - Press `CTRL+c` to **quit ytui-music**
-- If download is ongoing press `CTRL+ALT+C` to force quit
+- If a download is ongoing press `CTRL+ALT+C` to force quit
 
-## Adding to favourates
-1) Hilight the item you want to add or remove from favourates
-2) Press `f` to add or `u` to remove from favourates
+## Adding to favourites
+1) Highlight the item you want to add or remove from favourites
+2) Press `f` to add or `u` to remove from favourites
 3) To see your list
-    - Favourtaes music are shown in `Liked` section in sidebar
-    - Favourates playlist are shown in `My playlist` section in sidebar
-    - Favourtaes artist are shown in `Following` section in sidebar
+    - Favourite music is shown in `Liked` section in the sidebar
+    - Favourite playlist is shown in `My playlist` section in the sidebar
+    - Favourite artist is shown in `Following` section in the sidebar
 
 ---
 
 # Screenshots
-This is what ytui-music looks like. It may even look better on yours. ;)
+This is what ytui-music looks like. Your may look even better. ;)
 <details>
 
-<summary> Click to see screenshots</sumary>
+<summary> Click to see the screenshots</summary>
 
 ![Initial Screen](screenshots/initial-screen.png)
 ![Searching Music](screenshots/music-search.png)

--- a/config/src/initialize.rs
+++ b/config/src/initialize.rs
@@ -4,9 +4,9 @@ use lazy_static::lazy_static as compute_static;
 use rusqlite::{self, Connection};
 use std::sync::Mutex;
 
-pub const TB_FAVOURATES_MUSIC: &str = "favourates_music";
-pub const TB_FAVOURATES_PLAYLIST: &str = "favourates_playlist";
-pub const TB_FAVOURATES_ARTIST: &str = "favourates_artist";
+pub const TB_FAVOURITE_MUSIC: &str = "favourites_music";
+pub const TB_FAVOURITE_PLAYLIST: &str = "favourites_playlist";
+pub const TB_FAVOURITE_ARTIST: &str = "favourites_artist";
 
 compute_static! {
     pub static ref CONFIG: Config = {
@@ -22,7 +22,7 @@ compute_static! {
                     "yes" | "y" | "yeah" | "yep" => Config::default(),
 
                     _ => {
-                        eprintln!("A valid config is required for startup. Exiting..");
+                        eprintln!("A valid config is required for startup. Exiting.");
                         std::process::exit(1);
                     }
                 }
@@ -34,7 +34,7 @@ compute_static! {
         match ConfigContainer::give_me_storage() {
             Some(conn) => Mutex::new(conn),
             None => {
-                eprintln!("A valid storage is required for startup. Exiting..");
+                eprintln!("A valid storage is required for startup. Exiting.");
                 std::process::exit(1);
             }
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path;
 use std::time::Duration;
-pub mod initilize;
+pub mod initialize;
 
 pub const CONF_DIR_NAME: &str = "ytui_music";
 pub const CONFIG_FILE_NAME: &str = "config.json";
@@ -28,20 +28,20 @@ fn get_random_bool() -> bool {
 
 trait Random {
     #[must_use]
-    fn suffle(&self, timeout: Duration) -> Self;
+    fn shuffle(&self, timeout: Duration) -> Self;
 }
 impl<T> Random for Vec<T>
 where
     T: std::cmp::PartialEq + Clone,
 {
-    fn suffle(&self, timeout: Duration) -> Self {
+    fn shuffle(&self, timeout: Duration) -> Self {
         let length = self.len();
         let mut new_vector = Vec::with_capacity(length);
 
         let now = std::time::Instant::now();
         let mut current = 0;
         while new_vector.len() != length {
-            // When timwout occurs push all the reamining vector directly
+            // When timeout occurs push all the remaining vector directly
             if now.elapsed() > timeout {
                 for val in self {
                     if !new_vector.contains(val) {
@@ -70,11 +70,11 @@ pub struct ShortcutsKeys {
     pub quit: char,
     pub forward: char,
     pub backward: char,
-    pub suffle: char,
+    pub shuffle: char,
     pub repeat: char,
     pub view: char,
-    pub favourates_add: char,
-    pub favourates_remove: char,
+    pub favourites_add: char,
+    pub favourites_remove: char,
     pub vol_increase: char,
     pub vol_decrease: char,
 }
@@ -116,29 +116,29 @@ impl Default for ShortcutsKeys {
             // Same as forward but instead seek backward
             backward: '<',
 
-            // Turn suffle on if already is off and vice-versa
-            // Suffle on: play the playlist in random order
-            // Suffle off: play the playlist in as is order
-            suffle: 's',
+            // Turn shuffle on if already is off and vice-versa
+            // shuffle on: play the playlist in random order
+            // shuffle off: play the playlist in as is order
+            shuffle: 's',
 
-            // Turn repeat on if already is off and vice-versa
+            // Toggle repeat
             // Repeat on: Play all the items from playlist. If last item ends play first
             // Repeat off: If currenlt playing item ends play same item again. i.e repeat one
             repeat: 'r',
 
-            // This key will expand the content of playlist but do not play it
+            // This key will expand the content of playlist but not play it
             // Also will show the selection url
             view: 'v',
 
-            // Add the current selection to the favourates list
-            favourates_add: 'f',
+            // Add the current selection to the favourites list
+            favourites_add: 'f',
 
-            // Remove the current selection from the favourates lits. Adding and removing from
-            // favourates list are not done by same key because toggeling means first the exsistance of
+            // Remove the current selection from the favourites lits. Adding and removing from
+            // favourites list are not done by same key because toggling means first the existance of
             // given selection should be checked in database and then again query another INSERT/REMOVE
             // statement. However, if sepearte keys are used, only single INSERT/REMOVE query is to be
             // executed.
-            favourates_remove: 'u',
+            favourites_remove: 'u',
 
             // Key to increase the volume of playback
             vol_increase: '+',
@@ -191,7 +191,7 @@ impl Default for Theme {
             // Applies to the title (top-left corner of border) of the block
             block_title: (175, 125, 115),
 
-            // Color_(promary/secondary/tertiary) are for everything else other than above.
+            // Color_(primary/secondary/tertiary) are for everything else other than above.
             // Instead of relying on terminal color, using this will bring more consistency in the ui
             color_primary: (100, 250, 20),
             color_secondary: (250, 230, 70),
@@ -443,7 +443,7 @@ impl ConfigContainer {
         // So be sure we dont kill a single server instead distribute the load.
         // Here, it is achived by rearrenging the server list in random order
         // so that first server don't always have to be first to send request
-        config.servers.list = config.servers.list.suffle(Duration::from_secs(4));
+        config.servers.list = config.servers.list.shuffle(Duration::from_secs(4));
 
         Some(Self {
             config,
@@ -496,7 +496,7 @@ impl ConfigContainer {
                     config_dir = config_dir.join(CONF_DIR_NAME);
                     config_dir
                 } else {
-                    eprintln!("Cannot get you configuration directory to where to config of Ytui will be stored.");
+                    eprintln!("Cannot get the configuration directory to where to config of ytui will be stored.");
 
                     return None;
                 }
@@ -543,7 +543,7 @@ impl ConfigContainer {
         // The destination types fetcher::{MusicUnit, Playlistunit, ArtistUnit}
         // fiels are all decleared in string format. So on retriving with SELECT query
         // it makes easy to fetch columns without any conversion method
-        let create_favourates_table = format!(
+        let create_favourites_table = format!(
             "
                 CREATE TABLE IF NOT EXISTS {tb_music} (
                     id          TEXT    NOT NULL    PRIMARY KEY,
@@ -565,12 +565,12 @@ impl ConfigContainer {
                     count   TEXT    NOT NULL
                 );
            ",
-            tb_music = initilize::TB_FAVOURATES_MUSIC,
-            tb_playlist = initilize::TB_FAVOURATES_PLAYLIST,
-            tb_artist = initilize::TB_FAVOURATES_ARTIST
+            tb_music = initialize::TB_FAVOURITE_MUSIC,
+            tb_playlist = initialize::TB_FAVOURITE_PLAYLIST,
+            tb_artist = initialize::TB_FAVOURITE_ARTIST
         );
 
-        let res = connection.execute_batch(&create_favourates_table);
+        let res = connection.execute_batch(&create_favourites_table);
 
         if let Err(err) = res {
             eprintln!(

--- a/fetcher/src/lib.rs
+++ b/fetcher/src/lib.rs
@@ -120,14 +120,14 @@ pub enum ReturnAction {
     // Also Failed is active when fetcher had retried and now had exceed the retry count
     Failed,
     // This variant simply indicates that the request has failed but doing the same request for
-    // another time may suceed
+    // another time may succeed
     Retry,
-    // EOR avvrebration of End Of Result indicates that there is nothing more to fetch
-    // At this point the corresponding container have all the data either fetched at once
-    // like or had fetched the maximum page in pagination fetch
+    // EOR abbreviation of End Of Result indicates that there is nothing more to fetch
+    // At this point the corresponding container has all the data either fetched at once
+    // or had fetched the maximum page in pagination fetch
     // A common example is when all the 3/4 page of trending page have been fetched
-    // and user had seen the end. or all the search result have been srved
-    // At this condition the fetch has technicallt suceed and also tells that
+    // and user had seen the end. or all the search result have been served
+    // At this condition the fetch has technically succeeded and also means that
     // another retry on same query will return EOR again and again until new fetch is to be made
     EOR,
 }
@@ -147,7 +147,7 @@ pub struct Fetcher {
     // All the content in given playlist id is fetched at once and stored meaning
     // only single web request is needed and no other even when user asks for next page.
     // On the other hand this means for a playlist with large amount of content
-    // takes more time to initilized.
+    // takes more time to initialized.
     // The needed request will return the array of music data. And currently there is no way
     // to fetch only the necessary fields inside music struct. Which means even with playlist
     // of samll size, over data is returend by the data that is just ignored from our side. Thus
@@ -180,7 +180,7 @@ pub struct Fetcher {
     // First field: (String) is the query being searched for.
     search_res: SearchRes,
 
-    // The reqwest client itself. This is only initilized once per session.
+    // The reqwest client itself. This is only initialized once per session.
     client: reqwest::Client,
 
     // index that reference the servers[] field.

--- a/fetcher/src/utils.rs
+++ b/fetcher/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::{Fetcher, ReturnAction};
-use config::initilize::{
-    CONFIG, STORAGE, TB_FAVOURATES_ARTIST, TB_FAVOURATES_MUSIC, TB_FAVOURATES_PLAYLIST,
+use config::initialize::{
+    CONFIG, STORAGE, TB_FAVOURITE_ARTIST, TB_FAVOURITE_MUSIC, TB_FAVOURITE_PLAYLIST,
 };
 use reqwest;
 use std::iter::DoubleEndedIterator;
@@ -348,7 +348,7 @@ impl Fetcher {
         }
     }
 
-    pub async fn get_favourates_music(
+    pub async fn get_favourites_music(
         &mut self,
         page: usize,
     ) -> Result<Vec<super::MusicUnit>, ReturnAction> {
@@ -362,7 +362,7 @@ impl Fetcher {
             FROM {tb_name}
             LIMIT {from}, {count}
         ",
-            tb_name = TB_FAVOURATES_MUSIC,
+            tb_name = TB_FAVOURITE_MUSIC,
             from = lower_limit,
             count = self.item_per_page,
         );
@@ -371,7 +371,7 @@ impl Fetcher {
             Ok(val) => val,
             Err(err) => {
                 eprintln!(
-                    "Error preparing select statement for favourates music. Error: {err}",
+                    "Error preparing select statement for favourites music. Error: {err}",
                     err = err
                 );
                 return Err(ReturnAction::Failed);
@@ -390,7 +390,7 @@ impl Fetcher {
         let res = match results {
             Err(err) => {
                 eprintln!(
-                    "Cannot get results of favourates music. Error: {err}",
+                    "Cannot get results of favourites music. Error: {err}",
                     err = err
                 );
                 return Err(ReturnAction::Failed);
@@ -412,7 +412,7 @@ impl Fetcher {
         Ok(res)
     }
 
-    pub async fn get_favourates_playlist(
+    pub async fn get_favourites_playlist(
         &mut self,
         page: usize,
     ) -> Result<Vec<super::PlaylistUnit>, ReturnAction> {
@@ -426,7 +426,7 @@ impl Fetcher {
             FROM {tb_name}
             LIMIT {from}, {count}
         ",
-            tb_name = TB_FAVOURATES_PLAYLIST,
+            tb_name = TB_FAVOURITE_PLAYLIST,
             from = lower_limit,
             count = self.item_per_page,
         );
@@ -435,7 +435,7 @@ impl Fetcher {
             Ok(val) => val,
             Err(err) => {
                 eprintln!(
-                    "Error preparing select statement for favourates playlist. Error: {err}",
+                    "Error preparing select statement for favourites playlist. Error: {err}",
                     err = err
                 );
                 return Err(ReturnAction::Failed);
@@ -454,7 +454,7 @@ impl Fetcher {
         let res = match results {
             Err(err) => {
                 eprintln!(
-                    "Cannot get results of favourates music. Error: {err}",
+                    "Cannot get results of favourites music. Error: {err}",
                     err = err
                 );
                 return Err(ReturnAction::Failed);
@@ -477,7 +477,7 @@ impl Fetcher {
         Ok(res)
     }
 
-    pub async fn get_favourates_artist(
+    pub async fn get_favourites_artist(
         &mut self,
         page: usize,
     ) -> Result<Vec<super::ArtistUnit>, ReturnAction> {
@@ -491,7 +491,7 @@ impl Fetcher {
             FROM {tb_name}
             LIMIT {from}, {count}
         ",
-            tb_name = TB_FAVOURATES_ARTIST,
+            tb_name = TB_FAVOURITE_ARTIST,
             from = lower_limit,
             count = self.item_per_page,
         );
@@ -500,7 +500,7 @@ impl Fetcher {
             Ok(val) => val,
             Err(err) => {
                 eprintln!(
-                    "Error preparing select statement for favourates artist. Error: {err}",
+                    "Error preparing select statement for favourites artist. Error: {err}",
                     err = err
                 );
                 return Err(ReturnAction::Failed);
@@ -518,7 +518,7 @@ impl Fetcher {
         let res = match results {
             Err(err) => {
                 eprintln!(
-                    "Cannot get results of favourates artist. Error: {err}",
+                    "Cannot get results of favourites artist. Error: {err}",
                     err = err
                 );
                 return Err(ReturnAction::Failed);

--- a/front-end/src/about.txt
+++ b/front-end/src/about.txt
@@ -7,7 +7,7 @@ Problem ytui music tries to solve:
 - Have a nice basic function like searching and exploring trending content
 - Keyboard driven navigation and control
 - Download with single key combination key press
-- Track my favourates music, playlist and artist in local database
+- Track my favourites music, playlist and artist in local database
 
 Ytui-music says:
 - Do not open a whole browser just to listen to music
@@ -20,14 +20,14 @@ Ytui-music says:
 
 What you may not find:
 - Currently, managing playback queue is the only thing I miss from a full featured music player
-- Besides favourates playlist. Maintaining own playlist is also currently not available.
-  Instead, you may create a public playlist from official youtube and add those to favourates.
-  I am not a guy who manipulates playlist that much. I just few musics to favourates playlist.
+- Besides favourites playlist. Maintaining own playlist is also currently not available.
+  Instead, you may create a public playlist from official youtube and add those to favourites.
+  I am not a guy who manipulates playlist that much. I just few musics to favourites playlist.
 
 Toos used:
 mpv: To handle playback. Mpv seems to be only option that integrate well with online streaming.
      Well, many may cheer for vlc but it's online streaming side is less active compared to mpv
-sqlite: To store the local data like favourates list. Goto choice for embedded databse for decade
+sqlite: To store the local data like favourites list. Goto choice for embedded databse for decade
 youtube-dl: Everyone knows. youtube-dl handles so well to fetch youtbe-data
 rust: Empowering everyone to write efficient software. Well I'm empowered
 

--- a/front-end/src/cli.rs
+++ b/front-end/src/cli.rs
@@ -1,4 +1,4 @@
-use config::initilize::CONFIG;
+use config::initialize::CONFIG;
 use reqwest;
 use serde::{self, Deserialize};
 use tokio;
@@ -113,10 +113,10 @@ __   ___         _                           _
             toggle = keys.toggle_play,
             next = keys.next,
             prev = keys.prev,
-            suf = keys.suffle,
+            suf = keys.shuffle,
             rep = keys.repeat,
-            f_add = keys.favourates_add,
-            f_rm = keys.favourates_remove,
+            f_add = keys.favourites_add,
+            f_rm = keys.favourites_remove,
             srch = keys.start_search,
             view = keys.view,
             bkwd = keys.backward,
@@ -133,18 +133,18 @@ __   ___         _                           _
     }
 
     pub fn initialize_globals(&self) {
-        lazy_static::initialize(&config::initilize::INIT);
+        lazy_static::initialize(&config::initialize::INIT);
     }
 
     pub fn update(self) {
-        println!("Updating ytui-music to latest version....");
+        println!("Updating ytui-music to the latest version...");
 
         let mut download_path = String::new();
         while download_path.is_empty() {
-            println!("Enter path to store updated binary");
+            println!("Enter path to store the updated binary");
             std::io::stdin()
                 .read_line(&mut download_path)
-                .expect("Couldnot accept input");
+                .expect("Could not accept input");
             download_path = download_path.trim().to_string();
         }
 
@@ -155,7 +155,7 @@ __   ___         _                           _
         let download_path = download_path.as_path();
 
         println!(
-            "Latest version of ytui-music will be store in {}.",
+            "Latest version of ytui-music will be stored in {}.",
             match download_path.to_str() {
                 None => {
                     download_path.to_string_lossy().into_owned()
@@ -179,7 +179,7 @@ __   ___         _                           _
                 response
                     .bytes()
                     .await
-                    .expect("Couldn't extract bytes from recived binary.."),
+                    .expect("Couldn't extract bytes from received binary."),
             );
 
             if let Err(err) = res {
@@ -198,16 +198,16 @@ __   ___         _                           _
                 let response = self.download_binary(&binary_name).await;
                 match response {
                     None => {
-                        eprintln!("Cannot update ytui-music to latest version du to previous error.");
-                        eprintln!("To report this problem, you can file this issue in https://github.com/sudipghimire533/ytui-music/issues/");
+                        eprintln!("Cannot update ytui-music to latest version due to previous error.");
+                        eprintln!("To report this problem, you can file this issue at https://github.com/sudipghimire533/ytui-music/issues/");
                     }
                     Some(res) => {
-                        let sucess = after_download(res).await;
-                        if !sucess {
-                            eprintln!("Cannot write ytui-music to destination. Update failed..");
-                            eprintln!("To report this problem, you can file this issue in https://github.com/sudipghimire533/ytui-music/issues/");
+                        let success = after_download(res).await;
+                        if !success {
+                            eprintln!("Cannot write ytui-music to destination. Update failed.");
+                            eprintln!("To report this problem, you can file this issue at https://github.com/sudipghimire533/ytui-music/issues/");
                         } else {
-                            println!("Update sucess. Set executable permission if needed.");
+                            println!("Update successful. Set executable permission if needed.");
                         }
                     }
                 }
@@ -234,7 +234,7 @@ __   ___         _                           _
         let octets_array = match client_json.get(&assest_api_url).send().await {
             Err(err) => {
                 eprintln!(
-                    "Cannot get the release info from {url}.\n Erro: {err}",
+                    "Cannot get the release info from {url}.\n Error: {err}",
                     url = assest_api_url,
                     err = err,
                 );
@@ -260,12 +260,12 @@ __   ___         _                           _
                 break;
             }
         }
-        let asset = asset.expect("Empty asset array recived from github api");
+        let asset = asset.expect("Empty asset array received from github API");
 
         headers.insert(
             header::ACCEPT,
             header::HeaderValue::from_bytes(asset.content_type.as_bytes())
-                .expect("Invalid content type recived from github api"),
+                .expect("Invalid content type received from github api"),
         );
         let client_octet = reqwest::ClientBuilder::new()
             .default_headers(headers)
@@ -274,7 +274,7 @@ __   ___         _                           _
 
         // As of now binary is only of <= 5Mib so if binary happens to grow over time (which is not
         // expected as of now), then instead of holding binary in memory, it should written to file
-        // peridocially
+        // periodically
         let binary = match client_octet.get(&asset.url).send().await {
             Err(err) => {
                 eprintln!(

--- a/front-end/src/communicator.rs
+++ b/front-end/src/communicator.rs
@@ -7,27 +7,27 @@ use std::sync::{Arc, Condvar, Mutex};
 macro_rules! handle_response {
     ($response: expr, $state_original: expr, $win_index: expr, $target: ident) => {{
         let mut state = $state_original.lock().unwrap();
-        // return the boolean which is only truw when response is RETRY
+        // return the boolean which is only true when response is RETRY
         let mut need_retry = false;
         match $response {
             Ok(mut data) => {
-                state.status = "Success..";
+                state.status = "Success.";
                 data.shrink_to_fit();
                 state.$target.0 = data;
             }
             Err(e) => {
                 match e {
                     fetcher::ReturnAction::Failed => {
-                        state.status = "Fetch error..";
+                        state.status = "Fetch error.";
                     }
                     fetcher::ReturnAction::EOR => {
-                        state.status = "Result end..";
+                        state.status = "Result end.";
                         // TODO: Setting this to None means that the next page will always be 0.
                         // That being said when user tries to navigate to previous page after seeing
                         // EOR then still the fetched page will be 0. i.e again started from beginning.
                         // This is desirable when user tries to navigate to next page but is
-                        // undesiriable when user tries to navigate to previous page. For now, I can't
-                        // think of any workaround except really messing around with fetched_page be
+                        // undesirable when user tries to navigate to previous page. For now, I can't
+                        // think of any workaround except really messing around with fetched_page by
                         // changing the data type (may be new struct storing maximum page before EOR)
                         // and manipulating accordingly. But I have no intention to do so. So this todo
                         // message will be left todo forever
@@ -35,9 +35,9 @@ macro_rules! handle_response {
                         // Setting this to None means that in next iteration condition
                         // state.fetched_page[] != prev_<>_page wil be true but as for the whole if
                         // statement to be true the page should be Some value. That means when EOR is
-                        // reched the list will be empty until next iteration. If the if condition
+                        // reached the list will be empty until next iteration. If the if condition
                         // wouldn't have .is_some() check then in next iteration then zeroth page will
-                        // be fetched which is undesirable because it confuses weather it is reallt the
+                        // be fetched which is undesirable because it confuses whether it is really the
                         // next page or zeroth page after EOR
                         state.fetched_page[$win_index] = None;
                     }
@@ -62,7 +62,7 @@ pub async fn communicator<'st, 'nt>(
     let mut fetcher = fetcher::Fetcher::default();
 
     // variables with prev_ suffex are to be compared with respective current variables from state.
-    // This is to check weather anything have changed from previous data request from user so that
+    // This is to check whether anything has changed from previous data request from user so that
     // further request are made or not
     let (mut prev_musicbar_source, mut prev_playlistbar_source, mut prev_artistbar_source) = {
         // Initilization is done inside seperate scope so that this state variable is not visible
@@ -109,7 +109,7 @@ pub async fn communicator<'st, 'nt>(
             // clear the target so that noone gets confused if it the response from previous or
             // current request
             state.playlistbar.0.clear();
-            state.status = "Fetch playlist..";
+            state.status = "Fetching playlist...";
 
             notifier.notify_one();
 
@@ -138,8 +138,8 @@ pub async fn communicator<'st, 'nt>(
                 ui::PlaylistbarSource::Artist(ref artist_id) => {
                     playlist_content = fetcher.get_playlist_of_channel(artist_id, page).await;
                 }
-                ui::PlaylistbarSource::Favourates => {
-                    playlist_content = fetcher.get_favourates_playlist(page).await;
+                ui::PlaylistbarSource::Favourites => {
+                    playlist_content = fetcher.get_favourites_playlist(page).await;
                 }
                 ui::PlaylistbarSource::RecentlyPlayed => {
                     // TODO
@@ -169,7 +169,7 @@ pub async fn communicator<'st, 'nt>(
             std::mem::drop(state);
         }
 
-        // Checks and fills the artistbar.
+        // Checks and fills the artist bar.
         let mut state = state_original.lock().unwrap();
         if state.filled_source.2 != prev_artistbar_source
             || need_retry[MIDDLE_ARTIST_INDEX]
@@ -177,7 +177,7 @@ pub async fn communicator<'st, 'nt>(
                 && state.fetched_page[MIDDLE_ARTIST_INDEX].is_some())
         {
             state.artistbar.0.clear();
-            state.status = "Fetch artists..";
+            state.status = "Fetching artists...";
             notifier.notify_one();
 
             let page = state.fetched_page[MIDDLE_ARTIST_INDEX].unwrap();
@@ -190,8 +190,8 @@ pub async fn communicator<'st, 'nt>(
                 ui::ArtistbarSource::Search(ref term) => {
                     artist_content = fetcher.search_artist(term, page).await;
                 }
-                ui::ArtistbarSource::Favourates => {
-                    artist_content = fetcher.get_favourates_artist(page).await;
+                ui::ArtistbarSource::Favourites => {
+                    artist_content = fetcher.get_favourites_artist(page).await;
                 }
                 ui::ArtistbarSource::RecentlyPlayed => {
                     // TODO:
@@ -220,7 +220,7 @@ pub async fn communicator<'st, 'nt>(
                 && state.fetched_page[MIDDLE_MUSIC_INDEX].is_some())
         {
             state.musicbar.0.clear();
-            state.status = "Fetch music..";
+            state.status = "Fetching music...";
             notifier.notify_one();
 
             let page = state.fetched_page[MIDDLE_MUSIC_INDEX].unwrap();
@@ -242,8 +242,8 @@ pub async fn communicator<'st, 'nt>(
                 ui::MusicbarSource::Artist(ref artist_id) => {
                     music_content = fetcher.get_videos_of_channel(artist_id, page).await;
                 }
-                ui::MusicbarSource::Favourates => {
-                    music_content = fetcher.get_favourates_music(page).await;
+                ui::MusicbarSource::Favourites => {
+                    music_content = fetcher.get_favourites_music(page).await;
                 }
                 ui::MusicbarSource::RecentlyPlayed => {
                     // TODO: handle each variant with accurate function

--- a/front-end/src/help_keys.txt
+++ b/front-end/src/help_keys.txt
@@ -27,9 +27,9 @@ Below mentioned keys are based on your current configuration.
 `{bkwd}` : - Same as {{forward}} but seek backward
             keyName: {{backward}} & Default: <
 
-`{suf}` :   - Togge suffle/unsuffle.
-            Indicated by 'S'(suffle mode on) or '_'(suffle mode off)
-            keyName: {{suffle}} & Default: s
+`{suf}` :   - Togge shuffle/unshuffle.
+            Indicated by 'S'(shuffle mode on) or '_'(shuffle mode off)
+            keyName: {{shuffle}} & Default: s
 
 `{rep}` :   - Toggle repeat/unrepeat
             Indicated by 'R'(repeat whole playlist) or 'r'(repeat single track)
@@ -41,10 +41,10 @@ Below mentioned keys are based on your current configuration.
 `{srch}` :  - Move focus on search bar
             keyName: {{start_search}} & Default: \
 
-`{f_add}` : - Add current selection to favourates
-            keyName: {{favourates_add}} & Default: f
+`{f_add}` : - Add current selection to favourites
+            keyName: {{favourites_add}} & Default: f
 
-`{f_rm}` :  - Remove current selection if exists from favourates
+`{f_rm}` :  - Remove current selection if exists from favourites
             keyName: {{f_rm}} & Default: u
 
 `{v_inc}` : - Increase volume of playback. This will not affect the volme of system wide.

--- a/front-end/src/help_message.txt
+++ b/front-end/src/help_message.txt
@@ -14,7 +14,7 @@ delete:  : Delete configuration/storage file
            - config: Delete configuation file. This is located in <config-dir>/.ytui-music/config.json.
                 Run info config-location for exact location
                 On next run you will be asked weather to generate default config.
-           - db: Delete the database storage. This will delete your save data like favourates music.
+           - db: Delete the database storage. This will delete your save data like favourites music.
 
 info:    : Get the information about passed argument.
            Arguments:

--- a/front-end/src/ui/event.rs
+++ b/front-end/src/ui/event.rs
@@ -1,5 +1,5 @@
 use crate::ui::{self, utils::ExtendMpv};
-use config::initilize::{CONFIG, STORAGE};
+use config::initialize::{CONFIG, STORAGE};
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use std::{
     convert::TryFrom,
@@ -44,7 +44,7 @@ macro_rules! drop_and_call {
         std::mem::drop($state);
         $callback()
     }};
-    // This will call the function recived in second argument and pass the later arguments as that
+    // This will call the function received in second argument and pass the later arguments as that
     // function paramater
     ($state: expr, $callback: expr, $($args: expr)*) => {{
         std::mem::drop($state);
@@ -70,7 +70,7 @@ fn get_page(current: &Option<usize>, direction: HeadTo) -> usize {
 
 /*
 * The event_sender function is running in it's own seperate thread.
-* -> A loop is initilized where it waits for any event to happen (keypress and resize for now)
+* -> A loop is initialized where it waits for any event to happen (keypress and resize for now)
 * and call the corresponding closure to handle event.
 * -> Inside every closure state that are dependent to this event is checked. eg: checks active
 * window shile handleing left/right direction key
@@ -91,7 +91,7 @@ pub async fn event_sender(
 
     let download_counter: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
 
-    // There is several option in sidebar like trending/ favourates,
+    // There is several option in sidebar like trending/favourites,
     // this handler will change the selected option from sidebar depending on the direction user
     // move (Up or DOwn).
     let advance_sidebar = |direction: HeadTo| {
@@ -120,7 +120,7 @@ pub async fn event_sender(
         notifier.notify_all();
     };
 
-    // simialr to advance_music_list but instead rotate data in `playlistbar` variable of state
+    // similar to advance_music_list but instead rotate data in `playlistbar` variable of state
     let advance_playlist_list = |direction: HeadTo| {
         let mut state = state_original.lock().unwrap();
         let next_index;
@@ -134,7 +134,7 @@ pub async fn event_sender(
         notifier.notify_all();
     };
 
-    // simialr to advance_playlist_list but instead rotate data in `artistbar` variable of state
+    // similar to advance_playlist_list but instead rotate data in `artistbar` variable of state
     let advance_artist_list = |direction: HeadTo| {
         let mut state = state_original.lock().unwrap();
         // if the list is empty then do nothing else.
@@ -239,7 +239,7 @@ pub async fn event_sender(
     };
 
     // This is fires when user press any character key
-    // this will simpley push the recived character in search query term and update state
+    // this will simpley push the received character in search query term and update state
     // so can the added character becomes visible
     let handle_search_input = |ch| {
         state_original.lock().unwrap().search.0.push(ch);
@@ -247,7 +247,7 @@ pub async fn event_sender(
     };
 
     // This handler is fired when use press SEARCH_SH_KEY
-    // this will move the curson to the searchbar from which user can start to type the query
+    // this will move the cursor to the searchbar from which user can start to type the query
     let activate_search = || {
         let mut state = state_original.lock().unwrap();
         state.active = ui::Window::Searchbar;
@@ -258,7 +258,7 @@ pub async fn event_sender(
     // UP_ARROW will set the direction to PREV and DOWN_ARROW to NEXT
     // for now, these key will only handle the moving of list
     // So, depending on the window which is currently active, this closure will call
-    // the respective handler which will advance the corersponding list
+    // the respective handler which will advance the corresponding list
     let handle_up_down = |direction: HeadTo| {
         let state = state_original.lock().unwrap();
         match state.active {
@@ -328,7 +328,7 @@ pub async fn event_sender(
 
     let fill_fav_music = |direction: HeadTo| {
         let mut state = state_original.lock().unwrap();
-        state.filled_source.0 = ui::MusicbarSource::Favourates;
+        state.filled_source.0 = ui::MusicbarSource::Favourites;
         let page = get_page(&state.fetched_page[MIDDLE_MUSIC_INDEX], direction);
         state.fetched_page[MIDDLE_MUSIC_INDEX] = Some(page);
         notifier.notify_all();
@@ -336,7 +336,7 @@ pub async fn event_sender(
 
     let fill_fav_playlist = |direction: HeadTo| {
         let mut state = state_original.lock().unwrap();
-        state.filled_source.1 = ui::PlaylistbarSource::Favourates;
+        state.filled_source.1 = ui::PlaylistbarSource::Favourites;
         let page = get_page(&state.fetched_page[MIDDLE_PLAYLIST_INDEX], direction);
         state.fetched_page[MIDDLE_PLAYLIST_INDEX] = Some(page);
         notifier.notify_all();
@@ -344,7 +344,7 @@ pub async fn event_sender(
 
     let fill_fav_artist = |direction: HeadTo| {
         let mut state = state_original.lock().unwrap();
-        state.filled_source.2 = ui::ArtistbarSource::Favourates;
+        state.filled_source.2 = ui::ArtistbarSource::Favourites;
         let page = get_page(&state.fetched_page[MIDDLE_ARTIST_INDEX], direction);
         state.fetched_page[MIDDLE_ARTIST_INDEX] = Some(page);
         notifier.notify_all();
@@ -466,7 +466,7 @@ pub async fn event_sender(
     let handle_download = || async {
         let mut state = state_original.lock().unwrap();
 
-        // TODO: Ask for conformation before downloading
+        // TODO: Ask for confirmation before downloading
         let mut command = tokio::process::Command::new("youtube-dl");
         let download_url;
         if let Some(focused_index) = state.musicbar.1.selected() {
@@ -479,11 +479,11 @@ pub async fn event_sender(
             return;
         }
 
-        state.status = "Download started..";
+        state.status = "Download started...";
         state.active = ui::Window::Popup(
             "Downloading...",
             format!(
-                "Download of {} have an eye on your Music folder",
+                "Downloading {}, keep an eye on your Music folder",
                 download_url
             ),
         );
@@ -503,7 +503,7 @@ pub async fn event_sender(
         let counter_clone = Arc::clone(&download_counter);
 
         // Wait for 5 second just to make sure that command has finished executing.
-        // It usually donot take all those 5 seconds
+        // It usually doesn't take all those 5 seconds
         // Anyway, download won't finish before 5 seconds
         // Then just wait for command to finish by waiting for exit status
         // decrease the download queue count
@@ -515,7 +515,7 @@ pub async fn event_sender(
     };
 
     // If play is true it means also play the playlist
-    // if is false then only expand the playlist and show url but do not play it
+    // if it's false then only expand the playlist and show url but do not play it
     let select_playlist = |play: bool| {
         let mut state = state_original.lock().unwrap();
         if let Some(selected_index) = state.playlistbar.1.selected() {
@@ -565,7 +565,7 @@ pub async fn event_sender(
                 state.playback_behaviour.volume = vol;
             }
             None => {
-                state.status = "Volume error..";
+                state.status = "Volume error.";
             }
         };
 
@@ -637,10 +637,10 @@ pub async fn event_sender(
         }
     };
 
-    let handle_favourates = |add: bool| {
+    let handle_favourites = |add: bool| {
         let mut state = state_original.lock().unwrap();
 
-        state.status = "Processing..";
+        state.status = "Processing...";
 
         match state.active {
             ui::Window::Musicbar => {
@@ -650,12 +650,12 @@ pub async fn event_sender(
                     let selected_music =
                         &state.musicbar.0[selected_index] as *const fetcher::MusicUnit;
                     if add {
-                        state.add_music_to_favourates(unsafe { &*selected_music });
+                        state.add_music_to_favourites(unsafe { &*selected_music });
                     } else {
-                        state.remove_music_from_favourates(unsafe { &*selected_music });
+                        state.remove_music_from_favourites(unsafe { &*selected_music });
                     }
                 } else {
-                    state.status = "Nothing selected..";
+                    state.status = "Nothing selected.";
                 }
             }
 
@@ -664,12 +664,12 @@ pub async fn event_sender(
                     let selected_playlist =
                         &state.playlistbar.0[selected_index] as *const fetcher::PlaylistUnit;
                     if add {
-                        state.add_playlist_to_favourates(unsafe { &*selected_playlist });
+                        state.add_playlist_to_favourites(unsafe { &*selected_playlist });
                     } else {
-                        state.remove_playlist_from_favourates(unsafe { &*selected_playlist });
+                        state.remove_playlist_from_favourites(unsafe { &*selected_playlist });
                     }
                 } else {
-                    state.status = "Nothing selected..";
+                    state.status = "Nothing selected.";
                 }
             }
 
@@ -678,12 +678,12 @@ pub async fn event_sender(
                     let selected_artist =
                         &state.artistbar.0[selected_index] as *const fetcher::ArtistUnit;
                     if add {
-                        state.add_artist_to_favourates(unsafe { &*selected_artist });
+                        state.add_artist_to_favourites(unsafe { &*selected_artist });
                     } else {
-                        state.remove_artist_from_favourates(unsafe { &*selected_artist });
+                        state.remove_artist_from_favourites(unsafe { &*selected_artist });
                     }
                 } else {
-                    state.status = "Nothing selected..";
+                    state.status = "Nothing selected.";
                 }
             }
             _ => {}
@@ -733,7 +733,7 @@ pub async fn event_sender(
                                 toggle_play();
                             } else if ch == CONFIG.shortcut_keys.repeat {
                                 handle_repeat();
-                            } else if ch == CONFIG.shortcut_keys.suffle {
+                            } else if ch == CONFIG.shortcut_keys.shuffle {
                                 toggle_shuffle();
                             } else if ch == CONFIG.shortcut_keys.forward {
                                 seek_forward();
@@ -741,10 +741,10 @@ pub async fn event_sender(
                                 seek_backward();
                             } else if ch == CONFIG.shortcut_keys.view {
                                 handle_view();
-                            } else if ch == CONFIG.shortcut_keys.favourates_add {
-                                handle_favourates(true);
-                            } else if ch == CONFIG.shortcut_keys.favourates_remove {
-                                handle_favourates(false);
+                            } else if ch == CONFIG.shortcut_keys.favourites_add {
+                                handle_favourites(true);
+                            } else if ch == CONFIG.shortcut_keys.favourites_remove {
+                                handle_favourites(false);
                             } else if ch == CONFIG.shortcut_keys.prev {
                                 if is_with_control {
                                     change_track(HeadTo::Prev);

--- a/front-end/src/ui/mod.rs
+++ b/front-end/src/ui/mod.rs
@@ -113,7 +113,7 @@ pub struct MiddleBottom {
 // |        Rect (MusicConroller)       |
 // -------------------------------------
 // TODO: Split this area horzontally where small portion in right half shows the info like
-// suffle, repeat, pause/playing and volume using icon
+// shuffle, repeat, pause/playing and volume using icon
 pub struct BottomLayout {
     layout: Rect,
 }
@@ -154,7 +154,7 @@ pub struct Position {
 }
 
 // This function will:
-// 1) Initilize the terminal backend
+// 1) Initialize the terminal backend
 // 2) Get the layout of the ui
 // 3) print content in ui
 // 4) Run a loop waiting for state variable to change
@@ -246,7 +246,7 @@ pub fn draw_ui(state: &mut Arc<Mutex<State>>, cvar: &mut Arc<Condvar>) {
                 // This makes sure that background is not empty and user can
                 // see some things like progress of music player
                 if let Window::Popup(title, ref content) = state_unlocked.active {
-                    utils::show_pupop_text(screen, [title, content], &position.popup);
+                    utils::show_popup_text(screen, [title, content], &position.popup);
                 }
             })
             .unwrap();
@@ -314,7 +314,7 @@ pub enum MusicbarSource {
     Search(String),
     Trending,
     RecentlyPlayed,
-    Favourates,
+    Favourites,
     Playlist(String),
     Artist(String),
 }
@@ -322,19 +322,19 @@ pub enum MusicbarSource {
 pub enum PlaylistbarSource {
     Search(String),
     RecentlyPlayed,
-    Favourates,
+    Favourites,
     Artist(String),
 }
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ArtistbarSource {
     Search(String),
     RecentlyPlayed,
-    Favourates,
+    Favourites,
 }
 
 #[derive(Debug)]
 pub struct PlaybackBehaviour {
-    // true if user wishes to suffle the playlist
+    // true if user wishes to shuffle the playlist
     // false otherwise
     shuffle: bool,
     // true if user wished to repeat all items from playlist. i.e when last music of playlist ends

--- a/front-end/src/ui/utils.rs
+++ b/front-end/src/ui/utils.rs
@@ -7,17 +7,17 @@ use ui::shared_import::*;
 pub const SIDEBAR_LIST_COUNT: usize = 6;
 pub const SIDEBAR_LIST_ITEMS: [&str; SIDEBAR_LIST_COUNT] = [
     "Trending",
-    "Youtube Communinty",
+    "Youtube Community",
     "Liked songs",
     "My playlist",
     "Following",
     "Search",
 ];
-use config::initilize::{
-    CONFIG, STORAGE, TB_FAVOURATES_ARTIST, TB_FAVOURATES_MUSIC, TB_FAVOURATES_PLAYLIST,
+use config::initialize::{
+    CONFIG, STORAGE, TB_FAVOURITE_ARTIST, TB_FAVOURITE_MUSIC, TB_FAVOURITE_PLAYLIST,
 };
 
-pub fn show_pupop_text<'a, B>(frame: &mut tui::terminal::Frame<B>, text: [&'a str; 2], area: &Rect)
+pub fn show_popup_text<'a, B>(frame: &mut tui::terminal::Frame<B>, text: [&'a str; 2], area: &Rect)
 where
     B: Backend,
 {
@@ -332,7 +332,7 @@ impl<'parent> ui::BottomLayout {
 
     // Desired layout:
     // | Vol: <volume_level>
-    // | suffle | <strikethrough>suffle<strikethrough>
+    // | shuffle | <strikethrough>shuffle<strikethrough>
     // | (no-)repeat
     // | playing | paused (blinked)
     pub fn get_icons_set(state: &'parent ui::State) -> Paragraph<'parent> {
@@ -352,9 +352,9 @@ impl<'parent> ui::BottomLayout {
             repeat.content = Cow::Borrowed("repeat-all");
         }
 
-        let mut suffle = Span::styled("suffle", Style::list_highlight());
+        let mut shuffle = Span::styled("shuffle", Style::list_highlight());
         if !state.playback_behaviour.shuffle {
-            suffle.style = suffle.style.add_modifier(Modifier::CROSSED_OUT);
+            shuffle.style = shuffle.style.add_modifier(Modifier::CROSSED_OUT);
         }
 
         let volume = Span::styled(
@@ -366,7 +366,7 @@ impl<'parent> ui::BottomLayout {
             lines: [
                 Spans([volume].to_vec()),
                 Spans([repeat].to_vec()),
-                Spans([suffle].to_vec()),
+                Spans([shuffle].to_vec()),
                 Spans([paused_status].to_vec()),
             ]
             .to_vec(),
@@ -593,8 +593,8 @@ impl ExtendMpv for libmpv::Mpv {
                     new_vol = 100.0;
                 }
 
-                let sucess = self.set_property("volume", new_vol).is_ok();
-                if sucess {
+                let success = self.set_property("volume", new_vol).is_ok();
+                if success {
                     Some(new_vol as u8)
                 } else {
                     None
@@ -749,7 +749,7 @@ impl ui::State<'_> {
 }
 
 impl ui::State<'_> {
-    pub fn remove_music_from_favourates(&mut self, music: &fetcher::MusicUnit) {
+    pub fn remove_music_from_favourites(&mut self, music: &fetcher::MusicUnit) {
         let query = format!(
             "
             DELETE FROM
@@ -757,7 +757,7 @@ impl ui::State<'_> {
             WHERE
             fav_music.id = :id
         ",
-            tb_name = TB_FAVOURATES_MUSIC
+            tb_name = TB_FAVOURITE_MUSIC
         );
         let args = [(":id", &music.id)];
 
@@ -769,14 +769,14 @@ impl ui::State<'_> {
         }
     }
 
-    pub fn remove_playlist_from_favourates(&mut self, playlist: &fetcher::PlaylistUnit) {
+    pub fn remove_playlist_from_favourites(&mut self, playlist: &fetcher::PlaylistUnit) {
         let query = format!(
             "
             DELETE FROM
             {tb_name} as fav_playlist
             WHERE fav_playlist.id = :id
         ",
-            tb_name = TB_FAVOURATES_PLAYLIST
+            tb_name = TB_FAVOURITE_PLAYLIST
         );
         let args = [(":id", &playlist.id)];
 
@@ -788,14 +788,14 @@ impl ui::State<'_> {
         }
     }
 
-    pub fn remove_artist_from_favourates(&mut self, artist: &fetcher::ArtistUnit) {
+    pub fn remove_artist_from_favourites(&mut self, artist: &fetcher::ArtistUnit) {
         let query = format!(
             "
             DELETE FROM
             {tb_name} as fav_artist
             WHERE fav_artist.id = :id
         ",
-            tb_name = TB_FAVOURATES_ARTIST
+            tb_name = TB_FAVOURITE_ARTIST
         );
 
         let args = [(":id", &artist.id)];
@@ -808,7 +808,7 @@ impl ui::State<'_> {
         }
     }
 
-    pub fn add_artist_to_favourates(&mut self, artist: &fetcher::ArtistUnit) {
+    pub fn add_artist_to_favourites(&mut self, artist: &fetcher::ArtistUnit) {
         let query = format!(
             "
             INSERT OR REPLACE INTO
@@ -817,7 +817,7 @@ impl ui::State<'_> {
             VALUES
             (:id, :name, :count)
         ",
-            tb_name = TB_FAVOURATES_ARTIST
+            tb_name = TB_FAVOURITE_ARTIST
         );
 
         let args = [
@@ -834,7 +834,7 @@ impl ui::State<'_> {
         }
     }
 
-    pub fn add_music_to_favourates(&mut self, music: &fetcher::MusicUnit) {
+    pub fn add_music_to_favourites(&mut self, music: &fetcher::MusicUnit) {
         let query = format!(
             "
                 INSERT OR REPLACE INTO 
@@ -843,7 +843,7 @@ impl ui::State<'_> {
                 VALUES
                 (:id, :title, :author, :duration)
             ",
-            tb_name = TB_FAVOURATES_MUSIC
+            tb_name = TB_FAVOURITE_MUSIC
         );
 
         let args = [
@@ -861,14 +861,14 @@ impl ui::State<'_> {
         }
     }
 
-    pub fn add_playlist_to_favourates(&mut self, playlist: &fetcher::PlaylistUnit) {
+    pub fn add_playlist_to_favourites(&mut self, playlist: &fetcher::PlaylistUnit) {
         let query = format!(
             "
             INSERT OR REPLACE INTO {tb_name}
             (id, name, author, count)
             VALUES (:id, :name, :author, :count);
         ",
-            tb_name = TB_FAVOURATES_PLAYLIST
+            tb_name = TB_FAVOURITE_PLAYLIST
         );
 
         let args = [


### PR DESCRIPTION
Hey, I was reading through the project to learn the code and corrected a few typos.

Unfortunately, the `suffle -> shuffle` change is not backwards compatible since the config parsing expects the key `suffle`, but I don't know how to fix it. Could you take a look?