### PR TITLE
Fix implicit autoref errors in ui/mod.rs for Rust 1.80+

### DIFF
--- a/front-end/src/ui/mod.rs
+++ b/front-end/src/ui/mod.rs
@@ -215,9 +215,9 @@ pub fn draw_ui(state: &mut Arc<Mutex<State>>, cvar: &mut Arc<Condvar>) {
                 let state_ptr = &mut state_unlocked as *mut std::sync::MutexGuard<'_, State<'_>>;
                 let (mut music_state, mut playlist_state, mut artist_state);
                 unsafe {
-                    music_state = &mut (*state_ptr).musicbar.1;
-                    playlist_state = &mut (*state_ptr).playlistbar.1;
-                    artist_state = &mut (*state_ptr).artistbar.1;
+                    music_state = &mut (&mut (*state_ptr)).musicbar.1;
+                    playlist_state = &mut (&mut (*state_ptr)).playlistbar.1;
+                    artist_state = &mut (&mut (*state_ptr)).artistbar.1;
                 }
 
                 let music_table = MiddleLayout::get_music_container(&mut state_unlocked);


### PR DESCRIPTION
This PR fixes compilation errors caused by implicit autorefs in front-end/src/ui/mod.rs (lines 218-220) when using Rust 1.80+. The errors were due to #[deny(dangerous_implicit_autorefs)], and the fix follows the compiler's suggestion to make dereferencing explicit. Tested on Arch Linux with Rust 1.80.